### PR TITLE
Fix Angular CLI main entry configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
-# ngrx
+# ngrx workspace
 
-This is a repository for ngrx.
+This repository now contains an Angular workspace (`ngrx-playground`) that is preconfigured with NgRx dependencies so you can immediately begin practicing with actions, reducers, effects, and selectors.
+
+Navigate into the project and install dependencies to get started:
+
+```bash
+cd ngrx-playground
+npm install
+npm start
+```

--- a/ngrx-playground/.browserslistrc
+++ b/ngrx-playground/.browserslistrc
@@ -1,0 +1,7 @@
+last 1 Chrome version
+last 1 Firefox version
+last 2 Edge major versions
+last 2 Safari major versions
+last 2 iOS major versions
+Firefox ESR
+not IE 11

--- a/ngrx-playground/.editorconfig
+++ b/ngrx-playground/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/ngrx-playground/.gitignore
+++ b/ngrx-playground/.gitignore
@@ -1,0 +1,15 @@
+# Angular build outputs
+dist
+/tmp
+
+# Dependencies
+node_modules
+
+# IDEs and editors
+.vscode
+.idea
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/ngrx-playground/README.md
+++ b/ngrx-playground/README.md
@@ -1,0 +1,34 @@
+# NgRx Playground
+
+This project was generated manually to mirror the structure of a standard Angular workspace configured for NgRx experimentation. It ships with the Angular CLI configuration files, Karma unit testing setup, and initial NgRx dependencies so that you can immediately begin authoring actions, reducers, effects, selectors, and feature modules.
+
+## Getting started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Launch the development server:
+   ```bash
+   npm start
+   ```
+3. Run unit tests:
+   ```bash
+   npm test
+   ```
+
+You can generate additional Angular or NgRx constructs with the Angular CLI once the dependencies are installed, for example:
+
+```bash
+npx ng generate @ngrx/schematics:store State --module app
+```
+
+## Project structure
+
+- `src/app/app.component.*`: Root standalone component wired up for routing.
+- `src/app/app.routes.ts`: Routing configuration ready for feature routes.
+- `src/app/app.config.ts`: Application providers bootstrapped via `bootstrapApplication`.
+- `src/main.ts`: Angular bootstrap entry point.
+- `src/styles.scss`: Global styles.
+
+NgRx packages (`@ngrx/store`, `@ngrx/effects`, `@ngrx/store-devtools`, `@ngrx/entity`, and `@ngrx/router-store`) are already declared in `package.json`.

--- a/ngrx-playground/angular.json
+++ b/ngrx-playground/angular.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "ngrx-playground": {
+      "projectType": "application",
+      "schematics": {
+        "@schematics/angular:component": {
+          "standalone": true
+        },
+        "@schematics/angular:directive": {
+          "standalone": true
+        }
+      },
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/ngrx-playground",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": [
+              "zone.js"
+            ],
+            "tsConfig": "tsconfig.app.json",
+            "inlineStyleLanguage": "scss",
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
+            "styles": [
+              "src/styles.scss"
+            ],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "500kb",
+                  "maximumError": "1mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "2kb",
+                  "maximumError": "4kb"
+                }
+              ],
+              "outputHashing": "all"
+            },
+            "development": {
+              "buildOptimizer": false,
+              "optimization": false,
+              "vendorChunk": true,
+              "extractLicenses": false,
+              "sourceMap": true
+            }
+          },
+          "defaultConfiguration": "production"
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "configurations": {
+            "production": {
+              "browserTarget": "ngrx-playground:build:production"
+            },
+            "development": {
+              "browserTarget": "ngrx-playground:build:development"
+            }
+          },
+          "defaultConfiguration": "development"
+        },
+        "extract-i18n": {
+          "builder": "@angular-devkit/build-angular:extract-i18n",
+          "options": {
+            "browserTarget": "ngrx-playground:build"
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "polyfills": [
+              "zone.js",
+              "zone.js/testing"
+            ],
+            "tsConfig": "tsconfig.spec.json",
+            "karmaConfig": "karma.conf.js"
+          }
+        }
+      }
+    }
+  },
+  "cli": {
+    "schematicCollections": [
+      "@schematics/angular",
+      "@ngrx/schematics"
+    ]
+  }
+}

--- a/ngrx-playground/karma.conf.js
+++ b/ngrx-playground/karma.conf.js
@@ -1,0 +1,39 @@
+const { join } = require('path');
+const { constants } = require('karma');
+
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      jasmine: {},
+      clearContext: false
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true
+    },
+    coverageReporter: {
+      dir: join(__dirname, './coverage/ngrx-playground'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' }
+      ]
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: constants.LOG_INFO,
+    autoWatch: true,
+    browsers: ['Chrome'],
+    singleRun: false,
+    restartOnFileChange: true
+  });
+};

--- a/ngrx-playground/package.json
+++ b/ngrx-playground/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "ngrx-playground",
+  "version": "0.0.0",
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "watch": "ng build --watch --configuration development",
+    "test": "ng test"
+  },
+  "private": true,
+  "dependencies": {
+    "@angular/animations": "^17.3.7",
+    "@angular/common": "^17.3.7",
+    "@angular/compiler": "^17.3.7",
+    "@angular/core": "^17.3.7",
+    "@angular/forms": "^17.3.7",
+    "@angular/platform-browser": "^17.3.7",
+    "@angular/platform-browser-dynamic": "^17.3.7",
+    "@angular/router": "^17.3.7",
+    "@ngrx/effects": "^17.1.0",
+    "@ngrx/entity": "^17.1.0",
+    "@ngrx/router-store": "^17.1.0",
+    "@ngrx/store": "^17.1.0",
+    "@ngrx/store-devtools": "^17.1.0",
+    "rxjs": "~7.8.1",
+    "tslib": "^2.6.2",
+    "zone.js": "~0.14.5"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^17.3.6",
+    "@angular/cli": "^17.3.6",
+    "@angular/compiler-cli": "^17.3.7",
+    "@angular/language-service": "^17.3.7",
+    "@types/jasmine": "~5.1.4",
+    "jasmine-core": "~5.1.2",
+    "karma": "~6.4.3",
+    "karma-chrome-launcher": "~3.2.0",
+    "karma-coverage": "~2.2.0",
+    "karma-jasmine": "~5.1.0",
+    "karma-jasmine-html-reporter": "~2.1.0",
+    "typescript": "~5.4.5"
+  }
+}

--- a/ngrx-playground/src/app/app.component.html
+++ b/ngrx-playground/src/app/app.component.html
@@ -1,0 +1,9 @@
+<main class="main">
+  <header class="header">
+    <h1>{{ title | titlecase }}</h1>
+    <p>Welcome to your Angular + NgRx practice workspace.</p>
+  </header>
+  <section class="content">
+    <router-outlet></router-outlet>
+  </section>
+</main>

--- a/ngrx-playground/src/app/app.component.scss
+++ b/ngrx-playground/src/app/app.component.scss
@@ -1,0 +1,27 @@
+.main {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 3rem 1.5rem;
+  box-sizing: border-box;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 2rem;
+
+  h1 {
+    margin: 0 0 0.5rem;
+  }
+
+  p {
+    margin: 0;
+    color: #4a5568;
+  }
+}
+
+.content {
+  width: min(960px, 100%);
+}

--- a/ngrx-playground/src/app/app.component.spec.ts
+++ b/ngrx-playground/src/app/app.component.spec.ts
@@ -1,0 +1,31 @@
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { AppComponent } from './app.component';
+
+describe('AppComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule, AppComponent]
+    }).compileComponents();
+  });
+
+  it('should create the app', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    expect(app).toBeTruthy();
+  });
+
+  it(`should have the title 'ngrx-playground'`, () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    expect(app.title).toEqual('ngrx-playground');
+  });
+
+  it('should render the welcome message', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('p')?.textContent).toContain('Angular + NgRx');
+  });
+});

--- a/ngrx-playground/src/app/app.component.ts
+++ b/ngrx-playground/src/app/app.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [RouterOutlet],
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.scss']
+})
+export class AppComponent {
+  title = 'ngrx-playground';
+}

--- a/ngrx-playground/src/app/app.config.ts
+++ b/ngrx-playground/src/app/app.config.ts
@@ -1,0 +1,8 @@
+import { ApplicationConfig } from '@angular/core';
+import { provideRouter } from '@angular/router';
+
+import { routes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [provideRouter(routes)]
+};

--- a/ngrx-playground/src/app/app.routes.ts
+++ b/ngrx-playground/src/app/app.routes.ts
@@ -1,0 +1,3 @@
+import { Routes } from '@angular/router';
+
+export const routes: Routes = [];

--- a/ngrx-playground/src/index.html
+++ b/ngrx-playground/src/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>ngrx-playground</title>
+  <base href="/">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" type="image/x-icon" href="favicon.ico">
+</head>
+<body>
+  <app-root></app-root>
+</body>
+</html>

--- a/ngrx-playground/src/main.ts
+++ b/ngrx-playground/src/main.ts
@@ -1,0 +1,6 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+
+import { AppComponent } from './app/app.component';
+import { appConfig } from './app/app.config';
+
+bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));

--- a/ngrx-playground/src/polyfills.ts
+++ b/ngrx-playground/src/polyfills.ts
@@ -1,0 +1,1 @@
+import 'zone.js';

--- a/ngrx-playground/src/styles.scss
+++ b/ngrx-playground/src/styles.scss
@@ -1,0 +1,11 @@
+/* Global styles for the NGRX playground application */
+:root {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  color: #1f2933;
+  background-color: #f5f7fa;
+}
+
+body {
+  margin: 0;
+}

--- a/ngrx-playground/src/test.ts
+++ b/ngrx-playground/src/test.ts
@@ -1,0 +1,17 @@
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+declare const require: {
+  context(path: string, deep?: boolean, filter?: RegExp): {
+    keys(): string[];
+    <T>(id: string): T;
+  };
+};
+
+beforeAll(() => {
+  getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+});
+
+const context = require.context('./', true, /\.spec\.ts$/);
+context.keys().forEach(context);

--- a/ngrx-playground/tsconfig.app.json
+++ b/ngrx-playground/tsconfig.app.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc",
+    "types": []
+  },
+  "files": [
+    "src/main.ts"
+  ],
+  "include": [
+    "src/**/*.d.ts"
+  ]
+}

--- a/ngrx-playground/tsconfig.json
+++ b/ngrx-playground/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "module": "es2022",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+    "importHelpers": true,
+    "target": "es2022",
+    "lib": [
+      "es2022",
+      "dom"
+    ],
+    "types": []
+  }
+}

--- a/ngrx-playground/tsconfig.spec.json
+++ b/ngrx-playground/tsconfig.spec.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc/spec",
+    "types": [
+      "jasmine"
+    ]
+  },
+  "files": [
+    "src/polyfills.ts",
+    "src/test.ts"
+  ],
+  "include": [
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- replace the deprecated browser option with the required main entry in the Angular build target

## Testing
- not run (environment lacks npm registry access)


------
https://chatgpt.com/codex/tasks/task_e_68dc09b697708322aa810ebbc4ec2bbe